### PR TITLE
Improve set key

### DIFF
--- a/tests/test_dkey.py
+++ b/tests/test_dkey.py
@@ -45,9 +45,25 @@ def test_setitem():
         eq_(w[0].category, DeprecationWarning)
         eq_(str(w[0].message), 'Key `a` is deprecated. It shouldn\'t be used anymore.')
         eq_(100, my_dict['a'])
-        eq_(len(w), 2)
-        eq_(w[-1].category, DeprecationWarning)
-        eq_(str(w[-1].message), 'Key `a` is deprecated. It shouldn\'t be used anymore.')
+        eq_(len(w), 1)
+        my_dict['a'] = 120
+        eq_(len(w), 1)
+        eq_(120, my_dict['a'])
+        eq_(len(w), 1)
+
+    my_dict = deprecate_keys({'b': 12}, dkey('a', 'b'))
+    with warnings.catch_warnings(record=True) as w:
+        my_dict['a'] = 100
+        eq_(len(w), 1)
+        eq_(w[0].category, DeprecationWarning)
+        eq_(str(w[0].message), 'Key `a` is deprecated. Use `b` from now on.')
+        eq_(100, my_dict['a'])
+        eq_(len(w), 1)
+        my_dict['a'] = 120
+        eq_(len(w), 1)
+        eq_(120, my_dict['a'])
+        eq_(len(w), 1)
+        eq_(my_dict['b'], 12)
 
 @with_setup(setup_check_all_warnings)
 def test_custom_warning():


### PR DESCRIPTION
Additions
----------

Changes
---------
- ``__setitem__`` now only warns once when accessing a deprecated key. This avoids the warnings to propagate to code that is effectively unrelated to the deprecation. Also a bug was fixed that the value was set to the new key instead of the one chosen.


Deletions
---------


Affected Issues
---------------

resolves #8 