### PR TITLE
Added version info

### DIFF
--- a/dkey/__init__.py
+++ b/dkey/__init__.py
@@ -10,6 +10,20 @@ dkey
 ====
 Function to generate deprecated keys.
 
+__version__
+===========
+A string indicating which version of dkey is currently used.
+
+version_info
+============
+A tuple containing the currently used version.
+
 """
 from ._dkey import deprecate_keys as deprecate_keys
 from ._dkey import dkey as dkey
+
+from pbr.version import VersionInfo
+
+_v = VersionInfo('mgen').semantic_version()
+__version__ = _v.release_string()
+version_info = _v.version_tuple()

--- a/tests/test_dkey.py
+++ b/tests/test_dkey.py
@@ -9,8 +9,8 @@ from dkey import deprecate_keys, dkey
 class version_test_case(unittest.TestCase):
     def test_version_string_available(self):
         import dkey as dk
-        self.assertTrue(hasattr(dk, __version__))
-        self.assertTrue(hasattr(dk, version_info))
+        self.assertTrue(hasattr(dk, '__version__'))
+        self.assertTrue(hasattr(dk, 'version_info'))
 
 class dkey_test_case(unittest.TestCase):
     def test_number_of_keys_incorrect(self):

--- a/tests/test_dkey.py
+++ b/tests/test_dkey.py
@@ -6,6 +6,12 @@ from contextlib import contextmanager
 
 from dkey import deprecate_keys, dkey
 
+class version_test_case(unittest.TestCase):
+    def test_version_string_available(self):
+        import dkey as dk
+        self.assertTrue(hasattr(dk, __version__))
+        self.assertTrue(hasattr(dk, version_info))
+
 class dkey_test_case(unittest.TestCase):
     def test_number_of_keys_incorrect(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Additions
----------

- ``__version__`` and ``version_info`` module attributes were added
- Test were added to check if these attributes are available. Since I only forward the definitions of pbr I did not want to add checks for a specific version format.


Affected Issues
---------------

resolves #17 
